### PR TITLE
fix: update fast-query-parsers version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "fast_query_parsers"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "lazy_static",
  "pyo3",


### PR DESCRIPTION
Bumps lockfile version of this package from 0.2.0 to 0.3.0
Should resolve #10